### PR TITLE
Allow handling temporarily down redis nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ redis.call("GET", "mykey")
 - `write_timeout`: The write timeout, takes precedence over the general timeout when sending commands to the server.
 - `reconnect_attempts`: Specify how many times the client should retry to send queries. Defaults to `0`. Makes sure to read the [reconnection section](#reconnection) before enabling it.
 - `protocol:` The version of the RESP protocol to use. Default to `3`.
+- `retry_connection_delay:` The time in seconds to wait before attempting to query the same connection again. Cannot be used with `reconnect_attempts`. Defaults to `0`.
 
 ### Sentinel support
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ redis.call("GET", "mykey")
 - `write_timeout`: The write timeout, takes precedence over the general timeout when sending commands to the server.
 - `reconnect_attempts`: Specify how many times the client should retry to send queries. Defaults to `0`. Makes sure to read the [reconnection section](#reconnection) before enabling it.
 - `protocol:` The version of the RESP protocol to use. Default to `3`.
-- `retry_connection_delay:` The time in seconds to wait before attempting to query the same connection again. Cannot be used with `reconnect_attempts`. Defaults to `0`.
+- `retry_connecting_delay:` The time in seconds to wait before attempting to reconnect again. Defaults to `0`.
 
 ### Sentinel support
 

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -608,10 +608,10 @@ class RedisClient
         @raw_connection
       end
     elsif retryable
-      if config.retry_connection?
-        @connection_failed_at = false
+      if config.attempt_reconnecting?
+        @connection_error_at = false
       else
-        raise ConnectionError, "retry_connection_delay not reached"
+        raise CannotConnectError, "retry_connecting_delay not reached"
       end
       tries = 0
       connection = nil
@@ -689,7 +689,7 @@ class RedisClient
   rescue FailoverError
     raise
   rescue ConnectionError => error
-    @connection_failed_at ||= Time.now
+    @connection_error_at ||= Time.now
     raise CannotConnectError, error.message, error.backtrace
   rescue CommandError => error
     if error.message.include?("ERR unknown command `HELLO`")

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -601,6 +601,12 @@ class RedisClient
   def ensure_connected(retryable: true)
     close if !config.inherit_socket && @pid != Process.pid
 
+    if config.attempt_reconnecting?
+      @connection_error_at = false
+    else
+      raise CannotConnectError, "retry_connecting_delay not reached"
+    end
+
     if @disable_reconnection
       if block_given?
         yield @raw_connection
@@ -608,11 +614,6 @@ class RedisClient
         @raw_connection
       end
     elsif retryable
-      if config.attempt_reconnecting?
-        @connection_error_at = false
-      else
-        raise CannotConnectError, "retry_connecting_delay not reached"
-      end
       tries = 0
       connection = nil
       begin

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -14,7 +14,7 @@ class RedisClient
     module Common
       attr_reader :db, :password, :id, :ssl, :ssl_params, :command_builder, :inherit_socket,
         :connect_timeout, :read_timeout, :write_timeout, :driver, :connection_prelude, :protocol,
-        :middlewares_stack, :custom
+        :middlewares_stack, :custom, :retry_server_delay
 
       alias_method :ssl?, :ssl
 
@@ -36,7 +36,8 @@ class RedisClient
         command_builder: CommandBuilder,
         inherit_socket: false,
         reconnect_attempts: false,
-        middlewares: false
+        middlewares: false,
+        retry_server_delay: nil
       )
         @username = username
         @password = password
@@ -74,6 +75,7 @@ class RedisClient
           end
         end
         @middlewares_stack = middlewares_stack
+        @retry_server_delay = retry_server_delay
       end
 
       def username

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -37,7 +37,7 @@ class RedisClient
         inherit_socket: false,
         reconnect_attempts: false,
         middlewares: false,
-        retry_connection_delay: false
+        retry_connecting_delay: false
       )
         @username = username
         @password = password
@@ -75,7 +75,7 @@ class RedisClient
           end
         end
         @middlewares_stack = middlewares_stack
-        @retry_connection_delay = retry_connection_delay
+        @retry_connecting_delay = retry_connecting_delay
       end
 
       def username
@@ -107,15 +107,13 @@ class RedisClient
         false
       end
 
-      def retry_connection?
-        return true if @reconnect_attempts
-        return true unless @retry_connection_delay
-        return true unless @connection_failed_at
+      def attempt_reconnecting?
+        return true unless @retry_connecting_delay
+        return true unless @connection_error_at
 
-        time_to_next_reconnect = @connection_failed_at + @retry_connection_delay.seconds - Time.now
-        return true if time_to_next_reconnect.negative?
+        time_to_retry_connecting = @connection_error_at + @retry_connecting_delay.seconds - Time.now
+        return true if time_to_retry_connecting.negative?
 
-        puts { "retry_server_delay not reached for HOST: #{location} - #{time_to_next_reconnect} seconds remaining" }
         false
       end
 


### PR DESCRIPTION
### Problem

When using redis as a caching solution on a remote server we don't always want to retry a connection, and wait for it to fail again, and would rather the cache call failed quickly.  The current option of `reconnect_attempts` is not useful here as we would have to wait for each one to fail for each cache request until the web-server reaches its limit and attempts to get the oject from the db. 

### Proposed Solution

An option, `retry_connecting_delay`, that can be set to prevent the redis client from attempting a connection until the time limit is reached. This would enable the service using redis as a cache to quickly get back enough cache misses to refetch the object from the database. This attempts to acheive the same effect as the Dalli gems `down_retry_delay`[^1]

### Background

After making the transition from `ActiveSupport::Cache::MemcacheStore` to `ActiveSupport::Cache::RedisCacheStore` as a caching solution we noticed that the redis-client doesn't seem to handle dead nodes particularly well and will keep on attempting to connect to a node even if it gets back connection refused or other errors from it. When a server running a cache instance became unavailable (reboot, connection issue) it caused a significant drop in page load speeds as the cache would try to fetch from redis, eventually fail and then repeat. 

To solve this we introduced a patch to the redis client that rescues any connection error and places the connection in a 'waiting loop' so that each hit can quickly fail. Without the patch fetching an mp3 can take up to 4s when a cache server is down Vs 20ms with the patch running.

[^1]: https://github.com/petergoldstein/dalli/wiki/Dalli::Client-Options#failover--retry-options